### PR TITLE
新規お問合せ登録画面の「顧客情報詳細画面へ戻る」ボタンをアンカータグに変更

### DIFF
--- a/src/main/webapp/WEB-INF/view/inquiry_insert.jsp
+++ b/src/main/webapp/WEB-INF/view/inquiry_insert.jsp
@@ -56,9 +56,11 @@
 				</div>
 
 				<input type="hidden" name="customer_id" value="${customer.customer_id }">
-				<button type="submit" class="btn btn-primary btn-sm px-5" name="action" value="inquiry_insert_execute">登録</button>
-				<button type="submit" class="btn btn-primary btn-sm px-5" name="action" value="goto_customer_detail">顧客詳細画面へ戻る</button>
+				<button type="submit" class="btn btn-primary btn-sm px-5" name="action" value="inquiry_insert_execute">登録</button>&nbsp;&nbsp;&nbsp;&nbsp;
+				<a href="customer_detail?customer_id=${customer.customer_id }">顧客詳細画面へ戻る</a>
+				<!-- <button type="submit" class="btn btn-primary btn-sm px-5" name="action" value="goto_customer_detail">顧客詳細画面へ戻る</button> -->
 			</form>
+			
 
 		</div>
 	</c:param>


### PR DESCRIPTION
新規お問合せ登録画面の「顧客情報詳細画面へ戻る」ボタンをアンカータグに変更しました。
これにより、未入力のまま「顧客情報詳細画面へ戻る」ボタンをおすと顧客情報詳細画面へ遷移できない不具合を訂正しました。